### PR TITLE
Fix SPA navigation with Leptos A components

### DIFF
--- a/src/components/cta_section.rs
+++ b/src/components/cta_section.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 
 #[component]
 pub fn CtaSection() -> impl IntoView {
@@ -19,24 +20,24 @@ pub fn CtaSection() -> impl IntoView {
                             <br /> "導入サポートも充実しています。"
                         </p>
                         <div class="cta-buttons flex flex-wrap gap-3 justify-center items-center">
-                            <a href="/n-sup/tools" class="w-full sm:w-auto primary-button text-center px-6 py-3 rounded-lg font-semibold bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white transition-all duration-300 transform hover:scale-105">
+                            <A href="/n-sup/tools" attr:class="w-full sm:w-auto primary-button text-center px-6 py-3 rounded-lg font-semibold bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white transition-all duration-300 transform hover:scale-105">
                                 "工具管理"
-                            </a>
-                            <a href="/n-sup/employees" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-blue-500 text-blue-400 hover:bg-blue-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/employees" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-blue-500 text-blue-400 hover:bg-blue-500 hover:text-white transition-all duration-300">
                                 "従業員管理"
-                            </a>
-                            <a href="/n-sup/nc-programs" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-purple-500 text-purple-400 hover:bg-purple-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/nc-programs" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-purple-500 text-purple-400 hover:bg-purple-500 hover:text-white transition-all duration-300">
                                 "NCプログラム管理"
-                            </a>
-                            <a href="/n-sup/nc-support" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-cyan-500 text-cyan-400 hover:bg-cyan-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/nc-support" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-cyan-500 text-cyan-400 hover:bg-cyan-500 hover:text-white transition-all duration-300">
                                 "NCプログラム支援"
-                            </a>
-                            <a href="/n-sup/chat" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-green-500 text-green-400 hover:bg-green-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/chat" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-green-500 text-green-400 hover:bg-green-500 hover:text-white transition-all duration-300">
                                 "チャット"
-                            </a>
-                            <a href="/n-sup/ai-suggestions" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-yellow-500 text-yellow-400 hover:bg-yellow-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/ai-suggestions" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-yellow-500 text-yellow-400 hover:bg-yellow-500 hover:text-white transition-all duration-300">
                                 "AI工具提案"
-                            </a>
+                            </A>
                         </div>
                         <div class="cta-features">
                             <For

--- a/src/components/features.rs
+++ b/src/components/features.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 use crate::components::ui::{Container, SectionHeader, AnimatedCard};
 
 #[derive(Clone)]
@@ -90,9 +91,9 @@ pub fn FeatureCard(feature: Feature) -> impl IntoView {
             {
                 if let Some(url) = link_url {
                     view! {
-                        <a href={url} class="feature-card-link block h-full hover:transform hover:scale-105 transition-all duration-300">
+                        <A href=url attr:class="feature-card-link block h-full hover:transform hover:scale-105 transition-all duration-300">
                             {card_content}
-                        </a>
+                        </A>
                     }.into_any()
                 } else {
                     card_content.into_any()


### PR DESCRIPTION
## Summary
- Replace HTML anchor tags with Leptos A components in CTA section
- Update feature cards to use Leptos router for navigation  
- Fix client-side routing for GitHub Pages SPA deployment
- Enable proper navigation between landing page and application pages

## Problem
- CTA buttons and feature cards were using HTML `<a>` tags
- This caused full page reloads instead of SPA navigation
- Navigation from landing page to other pages was broken on GitHub Pages

## Solution
- Replace `<a>` with `leptos_router::components::A`
- Use `attr:class` instead of `class` for Leptos components
- Maintain all existing styling and functionality

## Test plan
- [x] All CTA buttons now use Leptos A components
- [x] Feature cards use proper SPA navigation
- [x] Code compiles without errors
- [x] Maintains existing visual styling

🤖 Generated with [Claude Code](https://claude.ai/code)