### PR TITLE
Complete navigation fixes for GitHub Pages SPA deployment

### DIFF
--- a/src/components/cta_section.rs
+++ b/src/components/cta_section.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 
 #[component]
 pub fn CtaSection() -> impl IntoView {
@@ -19,24 +20,24 @@ pub fn CtaSection() -> impl IntoView {
                             <br /> "導入サポートも充実しています。"
                         </p>
                         <div class="cta-buttons flex flex-wrap gap-3 justify-center items-center">
-                            <a href="/tools" class="w-full sm:w-auto primary-button text-center px-6 py-3 rounded-lg font-semibold bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white transition-all duration-300 transform hover:scale-105">
+                            <A href="/n-sup/tools" attr:class="w-full sm:w-auto primary-button text-center px-6 py-3 rounded-lg font-semibold bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white transition-all duration-300 transform hover:scale-105">
                                 "工具管理"
-                            </a>
-                            <a href="/employees" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-blue-500 text-blue-400 hover:bg-blue-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/employees" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-blue-500 text-blue-400 hover:bg-blue-500 hover:text-white transition-all duration-300">
                                 "従業員管理"
-                            </a>
-                            <a href="/nc-programs" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-purple-500 text-purple-400 hover:bg-purple-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/nc-programs" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-purple-500 text-purple-400 hover:bg-purple-500 hover:text-white transition-all duration-300">
                                 "NCプログラム管理"
-                            </a>
-                            <a href="/nc-support" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-cyan-500 text-cyan-400 hover:bg-cyan-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/nc-support" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-cyan-500 text-cyan-400 hover:bg-cyan-500 hover:text-white transition-all duration-300">
                                 "NCプログラム支援"
-                            </a>
-                            <a href="/chat" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-green-500 text-green-400 hover:bg-green-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/chat" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-green-500 text-green-400 hover:bg-green-500 hover:text-white transition-all duration-300">
                                 "チャット"
-                            </a>
-                            <a href="/ai-suggestions" class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-yellow-500 text-yellow-400 hover:bg-yellow-500 hover:text-white transition-all duration-300">
+                            </A>
+                            <A href="/n-sup/ai-suggestions" attr:class="w-full sm:w-auto secondary-button text-center px-6 py-3 rounded-lg font-semibold border-2 border-yellow-500 text-yellow-400 hover:bg-yellow-500 hover:text-white transition-all duration-300">
                                 "AI工具提案"
-                            </a>
+                            </A>
                         </div>
                         <div class="cta-features">
                             <For

--- a/src/components/features.rs
+++ b/src/components/features.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 use crate::components::ui::{Container, SectionHeader, AnimatedCard};
 
 #[derive(Clone)]
@@ -68,12 +69,12 @@ pub fn FeaturesSection() -> impl IntoView {
 #[component]
 pub fn FeatureCard(feature: Feature) -> impl IntoView {
     let link_url = match feature.title {
-        "工具管理" => Some("/tools"),
-        "従業員別管理" => Some("/employees"),
-        "NCプログラム管理" => Some("/nc-programs"),
-        "チャット機能" => Some("/chat"),
-        "AI工具提案" => Some("/ai-suggestions"),
-        "NCプログラム支援" => Some("/nc-support"),
+        "工具管理" => Some("/n-sup/tools"),
+        "従業員別管理" => Some("/n-sup/employees"),
+        "NCプログラム管理" => Some("/n-sup/nc-programs"),
+        "チャット機能" => Some("/n-sup/chat"),
+        "AI工具提案" => Some("/n-sup/ai-suggestions"),
+        "NCプログラム支援" => Some("/n-sup/nc-support"),
         _ => None,
     };
 
@@ -90,9 +91,9 @@ pub fn FeatureCard(feature: Feature) -> impl IntoView {
             {
                 if let Some(url) = link_url {
                     view! {
-                        <a href={url} class="feature-card-link block h-full hover:transform hover:scale-105 transition-all duration-300">
+                        <A href=url attr:class="feature-card-link block h-full hover:transform hover:scale-105 transition-all duration-300">
                             {card_content}
-                        </a>
+                        </A>
                     }.into_any()
                 } else {
                     card_content.into_any()

--- a/src/pages/ai_tool_suggestions.rs
+++ b/src/pages/ai_tool_suggestions.rs
@@ -190,7 +190,7 @@ pub fn AiToolSuggestions() -> impl IntoView {
             <div class="container mx-auto px-4 py-8">
                 <div class="mb-6">
                     <a 
-                        href="/" 
+                        href="/n-sup/" 
                         class="inline-flex items-center text-slate-300 hover:text-white transition-colors duration-200"
                     >
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/chat.rs
+++ b/src/pages/chat.rs
@@ -172,7 +172,7 @@ pub fn Chat() -> impl IntoView {
             <div class="container mx-auto px-4 py-8">
                 <div class="mb-6">
                     <a 
-                        href="/" 
+                        href="/n-sup/" 
                         class="inline-flex items-center text-slate-300 hover:text-white transition-colors duration-200"
                     >
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/employee_management.rs
+++ b/src/pages/employee_management.rs
@@ -160,7 +160,7 @@ pub fn EmployeeManagement() -> impl IntoView {
             <div class="container mx-auto px-4 py-8">
                 <div class="mb-6">
                     <a 
-                        href="/" 
+                        href="/n-sup/" 
                         class="inline-flex items-center text-slate-300 hover:text-white transition-colors duration-200"
                     >
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/nc_program_management.rs
+++ b/src/pages/nc_program_management.rs
@@ -163,7 +163,7 @@ pub fn NcProgramManagement() -> impl IntoView {
             <div class="container mx-auto px-4 py-8">
                 <div class="mb-6">
                     <a 
-                        href="/" 
+                        href="/n-sup/" 
                         class="inline-flex items-center text-slate-300 hover:text-white transition-colors duration-200"
                     >
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/nc_program_support.rs
+++ b/src/pages/nc_program_support.rs
@@ -232,7 +232,7 @@ pub fn NcProgramSupport() -> impl IntoView {
             <div class="container mx-auto px-4 py-8">
                 <div class="mb-6">
                     <a 
-                        href="/" 
+                        href="/n-sup/" 
                         class="inline-flex items-center text-slate-300 hover:text-white transition-colors duration-200"
                     >
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/tool_management.rs
+++ b/src/pages/tool_management.rs
@@ -109,7 +109,7 @@ pub fn ToolManagement() -> impl IntoView {
             <div class="container mx-auto px-4 py-8">
                 <div class="mb-6">
                     <a 
-                        href="/" 
+                        href="/n-sup/" 
                         class="inline-flex items-center text-slate-300 hover:text-white transition-colors duration-200"
                     >
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- Fix all home button links to use /n-sup/ prefix across all pages
- Replace HTML anchor tags with Leptos A components in CTA section and feature cards
- Update all navigation URLs to use correct GitHub Pages subpath
- Ensure proper client-side routing throughout the application

## Problem
- Navigation from landing page to other pages was broken on GitHub Pages
- Home buttons were redirecting to NotFound page instead of landing page
- HTML `<a>` tags were causing full page reloads instead of SPA navigation
- Missing /n-sup/ prefix in URLs for GitHub Pages deployment

## Solution
- Replace `<a>` with `leptos_router::components::A` for SPA navigation
- Add /n-sup/ prefix to all internal navigation links
- Use `attr:class` instead of `class` for Leptos router components
- Maintain all existing styling and functionality

## Files Changed
- `src/components/cta_section.rs`: Convert CTA buttons to Leptos A components
- `src/components/features.rs`: Update feature cards with proper routing
- All page files: Fix home button navigation links

## Test plan
- [x] All navigation links updated with GitHub Pages subpath
- [x] CTA buttons use Leptos A components for SPA navigation
- [x] Feature cards properly route to application pages
- [x] Home buttons redirect to landing page correctly
- [x] Code compiles without errors
- [x] Maintains existing visual styling

🤖 Generated with [Claude Code](https://claude.ai/code)